### PR TITLE
changed POM java version to 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: java
+jdk:
+  - openjdk11
 services:
   - mongodb
 addons:

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 	<description>Demo project for Spring Boot</description>
 
 	<properties>
-		<java.version>1.8</java.version>
+		<java.version>1.11</java.version>
 	</properties>
 
 <dependencies>
@@ -60,6 +60,14 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.8.0</version>
+				<configuration>
+					<release>11</release> <!-- Java release number -->
+				</configuration>
 			</plugin>
 		</plugins>
 	</build>


### PR DESCRIPTION
I was getting a few warnings saying that we specify that we are using java 8, but actually I am using java 11.

Not really a problem, but I was always told to get rid of all the warnings if possible, and no warning is better than any warning.