### PR TITLE
added loading of data to travis, and removed sleep

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ addons:
     token:
       secure: $SONAR_TOKEN # encrypted value of your token
 before_script:
-  - sleep 15
+  - mongorestore -d movies src/main/resources/movies
 script:
   # the following command line builds the project, runs the tests with coverage and then execute the SonarCloud analysis
   - mvn clean verify sonar:sonar -Dsonar.login=$SONAR_LOGIN


### PR DESCRIPTION
I don't think the `sleep 15` command was necessary so I removed it, and I added a command that should load the movie data into the mongoDB so that we can use a proper data.

It is important that this PR gets merged before #8 , otherwise the tests might fail.